### PR TITLE
Hba rule order

### DIFF
--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -133,4 +133,67 @@ describe 'postgresql::server::config', :type => :class do
         .with_content(/.include \/usr\/lib64\/systemd\/system\/postgresql-9.5.service/)
     end
   end
+
+  describe 'with managed pg_hba_conf' do
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          version => '9.5',
+        }->
+        class { 'postgresql::server':
+          manage_pg_hba_conf => true,
+        }
+      EOS
+    end
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '7.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
+      }
+    end
+    it 'should have hba default' do
+      is_expected.to contain_postgresql__server__pg_hba_rule('local access as postgres user')
+    end
+  end
+
+  describe 'with managed pg_hba_conf and ipv4acls' do
+    let (:pre_condition) do
+      <<-EOS
+        class { 'postgresql::globals':
+          version => '9.5',
+        }->
+        class { 'postgresql::server':
+          manage_pg_hba_conf => true,
+          ipv4acls => [
+            'hostnossl all all 0.0.0.0/0 reject',
+            'hostssl all all 0.0.0.0/0 md5'
+          ]
+        }
+      EOS
+    end
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+        :operatingsystem => 'CentOS',
+        :operatingsystemrelease => '7.0',
+        :concat_basedir => tmpfilename('server'),
+        :kernel => 'Linux',
+        :id => 'root',
+        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        :selinux => true,
+      }
+    end
+    it 'should have hba rule default' do
+      is_expected.to contain_postgresql__server__pg_hba_rule('local access as postgres user')
+    end
+    it 'should have hba rule ipv4acls' do
+      is_expected.to contain_postgresql__server__pg_hba_rule('postgresql class generated rule ipv4acls 0')
+    end
+  end
 end

--- a/spec/unit/classes/server/config_spec.rb
+++ b/spec/unit/classes/server/config_spec.rb
@@ -134,34 +134,6 @@ describe 'postgresql::server::config', :type => :class do
     end
   end
 
-  describe 'with managed pg_hba_conf' do
-    let (:pre_condition) do
-      <<-EOS
-        class { 'postgresql::globals':
-          version => '9.5',
-        }->
-        class { 'postgresql::server':
-          manage_pg_hba_conf => true,
-        }
-      EOS
-    end
-    let :facts do
-      {
-        :osfamily => 'RedHat',
-        :operatingsystem => 'CentOS',
-        :operatingsystemrelease => '7.0',
-        :concat_basedir => tmpfilename('server'),
-        :kernel => 'Linux',
-        :id => 'root',
-        :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        :selinux => true,
-      }
-    end
-    it 'should have hba default' do
-      is_expected.to contain_postgresql__server__pg_hba_rule('local access as postgres user')
-    end
-  end
-
   describe 'with managed pg_hba_conf and ipv4acls' do
     let (:pre_condition) do
       <<-EOS


### PR DESCRIPTION
Adding an rspec test to test the ability to use the ipv4acls parameter successfully.
This test fails under master branch, but passes with the addition of `Variant` in `pg_hba_rule.pp`